### PR TITLE
Adds Dockerfile.shiny and configuration for openshift deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -11,7 +11,8 @@ RUN install2.r --deps TRUE \
  corrr  \
  lubridate \
  shinyWidgets \
- causaleffect
+ causaleffect \
+ plotly
 
 COPY ./shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf
 RUN chown -R shiny /srv/shiny-server/

--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -1,0 +1,33 @@
+FROM rocker/shiny-verse:latest
+LABEL maintainer="Dan Leehr <dan.leehr@duke.edu>"
+
+# Install texlive-xetex for PDF generation
+RUN apt-get update && apt-get install -y texlive-xetex
+
+
+RUN install2.r --deps TRUE \
+ here \
+ janitor \
+ corrr  \
+ lubridate \
+ shinyWidgets \
+ causaleffect
+
+COPY ./shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf
+RUN chown -R shiny /srv/shiny-server/
+RUN chown -R shiny /var/lib/shiny-server/
+
+# OpenShift gives a random uid for the user and some programs try to find a username from the /etc/passwd.
+# Let user to fix it, but obviously this shouldn't be run outside OpenShift
+RUN chmod ug+rw /etc/passwd
+COPY ./shiny/fix-username.sh /fix-username.sh
+COPY ./shiny/shiny-server.sh /usr/bin/shiny-server.sh
+RUN chmod a+rx /usr/bin/shiny-server.sh
+
+# Make sure the directory for individual app logs exists and is usable
+RUN chmod -R a+rwX /var/log/shiny-server
+RUN chmod -R a+rwX /var/lib/shiny-server
+
+COPY ./code/* /srv/shiny-server/
+RUN touch /srv/.here
+WORKDIR /srv/shiny-server/

--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -12,7 +12,9 @@ RUN install2.r --deps TRUE \
  lubridate \
  shinyWidgets \
  causaleffect \
- plotly
+ plotly \
+ networkD3 \
+ feather
 
 COPY ./shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf
 RUN chown -R shiny /srv/shiny-server/

--- a/openshift/CreateGeneSummaryJob.yaml
+++ b/openshift/CreateGeneSummaryJob.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-gene-summary
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: create-gene-summary
+        image: dleehr/depmap:code
+        command: ["Rscript"]
+        args:
+          - "/depmap/code/create_gene_summary.R"
+          - "--destdir"
+          - "/depmap-data/"
+        volumeMounts:
+        - mountPath: /depmap-data
+          name: depmap-data
+        env:
+        - name: ENTREZ_KEY
+          valueFrom:
+            secretKeyRef:
+              name: entrez-secret
+              key: apikey
+      volumes:
+      - name: depmap-data
+        persistentVolumeClaim:
+          claimName: depmap-dev-pvc

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,24 @@
+depmap-shiny
+============
+
+Openshift deployment of Depmap application using shiny-server
+
+## Contents
+
+- CreateGeneSummaryJob.yaml: Kubernetes batch job to create `gene_summary.RData` - WIP
+- application.yaml: Tweaked output of `process-template.sh`
+- process-template.sh: Script using [juhahu/shiny-openshift](https://github.com/juhahu/shiny-openshift/) to bootstrap Openshift resources in `application.yaml`
+- params: Parameters used in the template, named in `process-template.sh`
+
+## Deployment
+
+1. Create Openshift objects (BuildConfig, DeploymentConfig, Route, Service, PersistentVolumeClaim): `oc create -f application.yaml`
+2. Wait for build to complete and deployment to start
+3. Place data files on the PersistentVolume: e.g. `oc cp ./data/gene_summary.RData depmap-shiny-1-xxxxx:/srv/data/`
+4. Visit the public route at http://depmap-shiny.apps.cloud.duke.edu to verify application is running
+
+## Notes / TODOs
+
+- The template is a good way to get shiny server up and running, but includes examples and packages we do not need
+- The shiny application is built from Dockerfile.shiny, but the template does not allow for customization of the `dockerfilePath`, so this has been manually added to the BuildConfig in `application.yaml`.
+- The CreateGeneSummaryJob does start and uses the NCBI API key (it must be in a secret), but in my testing on dev, the job did not finish, so instead I've just provided the

--- a/openshift/application.yaml
+++ b/openshift/application.yaml
@@ -1,0 +1,139 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: shinyserver
+      template: shinyserver
+    name: depmap-shiny-pvc
+  spec:
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: 1Gi
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: shinyserver
+      template: shinyserver
+    name: depmap-shiny
+  spec:
+    ports:
+    - name: depmap-shiny-service
+      port: 80
+      targetPort: 3838
+    selector:
+      app: depmap-shiny
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: http://{.spec.host}
+    labels:
+      app: shinyserver
+      template: shinyserver
+    name: depmap-shiny-route
+  spec:
+    host: depmap-shiny.apps.cloud.duke.edu
+    path: /
+    to:
+      kind: Service
+      name: depmap-shiny
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the appliation image
+    labels:
+      app: shinyserver
+      template: shinyserver
+    name: depmap-shiny
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      description: Defines how to build the application
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      app: shinyserver
+      template: shinyserver
+    name: depmap-shiny
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: depmap-shiny:latest
+    source:
+      contextDir: ""
+      git:
+        ref: openshift-shiny-simple
+        uri: https://github.com/Duke-GCB/depmap.git
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile.shiny
+    triggers:
+    - type: ImageChange
+    - type: ConfigChange
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: R Shiny server deployment
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      app: shinyserver
+      template: shinyserver
+    name: depmap-shiny
+  spec:
+    replicas: 1
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: depmap-shiny
+        name: depmap-shiny
+      spec:
+        containers:
+        - image: depmap-shiny:latest
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3838
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          name: shinyserver
+          ports:
+          - containerPort: 3838
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3838
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          resources:
+            limits:
+              memory: 1G
+          volumeMounts:
+          - mountPath: /srv/data
+            name: depmap-shiny-vol
+        volumes:
+        - name: depmap-shiny-vol
+          persistentVolumeClaim:
+            claimName: depmap-shiny-pvc
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - shinyserver
+        from:
+          kind: ImageStreamTag
+          name: depmap-shiny:latest
+      type: ImageChange
+    - type: ConfigChange
+kind: List
+metadata: {}

--- a/openshift/application.yaml
+++ b/openshift/application.yaml
@@ -69,8 +69,8 @@ items:
     source:
       contextDir: ""
       git:
-        ref: openshift-shiny-simple
-        uri: https://github.com/Duke-GCB/depmap.git
+        ref: deploy
+        uri: https://github.com/hirscheylab/depmap.git
       type: Git
     strategy:
       dockerStrategy:

--- a/openshift/params
+++ b/openshift/params
@@ -1,0 +1,5 @@
+APPLICATION_DOMAIN_SUFFIX="apps.cloud.duke.edu"
+MEMORY_LIMIT="1G"
+NAME="depmap-shiny"
+SOURCE_REPOSITORY_REF="deploy"
+SOURCE_REPOSITORY_URL="https://github.com/hirscheylab/depmap.git"

--- a/openshift/process-template.sh
+++ b/openshift/process-template.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+oc process \
+  -f https://raw.githubusercontent.com/juhahu/shiny-openshift/master/shinytemplate.yml \
+  --param-file params \
+  -o yaml
+

--- a/shiny/fix-username.sh
+++ b/shiny/fix-username.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+tempfile=$(mktemp)
+sed -e "s/^shiny.*//g" /etc/passwd > $tempfile
+cp $tempfile /etc/passwd
+echo "shiny:x:$(id -u):$(id -g)::/tmp:/bin/bash" >> /etc/passwd
+rm -f $tempfile

--- a/shiny/shiny-server.conf
+++ b/shiny/shiny-server.conf
@@ -1,0 +1,21 @@
+# Instruct Shiny Server to run applications as the user "shiny"
+run_as shiny;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  # Define a location at the base URL
+  location / {
+
+    # Host the directory of Shiny Apps stored in this directory
+    site_dir /srv/shiny-server/;
+
+    # Log all Shiny output to files in this directory
+    log_dir /var/log/shiny-server;
+
+    # When a user visits the base URL rather than a particular application,
+    # an index of the applications available in this directory will be shown.
+    directory_index on;
+  }
+}

--- a/shiny/shiny-server.sh
+++ b/shiny/shiny-server.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+sh /fix-username.sh
+
+# Make sure the directory for individual app logs exists
+#mkdir -p /var/log/shiny-server
+#chown shiny.shiny /var/log/shiny-server
+
+if [ "$APPLICATION_LOGS_TO_STDOUT" = "false" ];
+then
+    exec shiny-server 2>&1
+else
+    # start shiny server in detached mode
+    exec shiny-server 2>&1 &
+
+    # push the "real" application logs to stdout with xtail
+    exec xtail /var/log/shiny-server/
+
+fi


### PR DESCRIPTION
- `/Dockerfile.shiny` uses `rocker/shiny-verse` and installs required packages for our shiny app
- `/shiny/` directory includes server-side configs and scripts for launching dockerized shiny server
- `/openshift/` directory provides openshift resources for build and deploy.