### PR TITLE
Add cowplot and other requirements to shiny dockerfile

### DIFF
--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -15,7 +15,6 @@ RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE \
  feather \
  tidygraph \
  cowplot \
- ggplotly \
  digest \
  patchwork \
  viridis \

--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -19,6 +19,7 @@ RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE \
  patchwork \
  viridis \
  pander \
+ DT \
  ggraph
 
 COPY ./shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf

--- a/Dockerfile.shiny
+++ b/Dockerfile.shiny
@@ -10,12 +10,16 @@ RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE \
  janitor \
  corrr  \
  lubridate \
- shinyWidgets \
- causaleffect \
  plotly \
  networkD3 \
  feather \
  tidygraph \
+ cowplot \
+ ggplotly \
+ digest \
+ patchwork \
+ viridis \
+ pander \
  ggraph
 
 COPY ./shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf

--- a/code/app.R
+++ b/code/app.R
@@ -13,12 +13,13 @@ library(ggraph)
 library(viridis)
 library(cowplot)
 library(plotly)
+library(DT)
 
 #LOAD DATA-----
 #read current release information
 source(here::here("code", "current_release.R"))
 
-#read data from creat_gene_summary.R
+#read data from create_gene_summary.R
 read_gene_summary_into_environment <- function(tmp.env) {
   # Read gene_summary saved as RData using: save(gene_summary, file=here::here("data", "gene_summary.RData"))
   load(here::here("data", "gene_summary.RData"), envir=tmp.env)

--- a/code/app.R
+++ b/code/app.R
@@ -342,13 +342,13 @@ render_complete_report <- function (file, gene_symbol, tmp.env) { #how to levera
   dep_bottom <- make_bottom_table(gene_symbol)
   flat_bottom_complete <- make_enrichment_table(master_negative, gene_symbol)
   graph_report <- make_graph_report(gene_symbol)
-  rmarkdown::render("report_depmap_app.rmd", output_file = file)
+  rmarkdown::render("report_depmap_app.Rmd", output_file = file)
 
 }
 render_dummy_report <- function (file, gene_symbol, tmp.env) {
   fav_gene_summary <- tmp.env$gene_summary %>%
     filter(approved_symbol == gene_symbol)
-  rmarkdown::render("report_dummy_depmap.rmd", output_file = file)
+  rmarkdown::render("report_dummy_depmap.Rmd", output_file = file)
 }
 
 # Define the fields we want to save from the form

--- a/shiny/shiny-server.conf
+++ b/shiny/shiny-server.conf
@@ -1,6 +1,8 @@
 # Instruct Shiny Server to run applications as the user "shiny"
 run_as shiny;
 
+app_init_timeout 180;
+
 # Define a server that listens on port 3838
 server {
   listen 3838;


### PR DESCRIPTION
Adds the following to the docker file used to run the shiny webserver:
- cowplot used in [app.R](https://github.com/hirscheylab/ddh/blob/aeab2187e864d516f598858dbf57960ee04930ac/code/app.R#L14)
- digest used in [app.R](https://github.com/hirscheylab/ddh/blob/aeab2187e864d516f598858dbf57960ee04930ac/code/app.R#L369)
- patchwork used in [app.R](https://github.com/hirscheylab/ddh/blob/56cda91836d2cd95ba63c38502ce825c649740ee/code/report_depmap_app.Rmd#L14)
- viridis used in [methods.Rmd](https://github.com/hirscheylab/ddh/blob/aeab2187e864d516f598858dbf57960ee04930ac/code/methods.Rmd#L15)
- pander used in [report_depmap_app.R](https://github.com/hirscheylab/ddh/blob/56cda91836d2cd95ba63c38502ce825c649740ee/code/report_depmap_app.Rmd#L13)

Removes shinyWidgets and causaleffect since they don't appear to be currently used.

Additional changes to fix issues deploying:
- rename markdown files to match actual case in code/app.R
- increases startup timeout to 180 seconds

Fixes #13
