### PR TITLE
updates 19Q3 to 19Q4 in Makefile/openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean_container:
 # Map simple target names to the files on which they depend
 container_image: singularity/depmap.sif
 gene_summary: data/gene_summary.RData
-depmap_data: data/19Q3_achilles_cor.RData data/19Q3_achilles.RData data/19Q3_expression.RData data/19Q3_expression_id.RData data/19Q3_expression_join.RData
+depmap_data: data/19Q4_achilles_cor.RData data/19Q4_achilles.RData data/19Q4_expression.RData data/19Q4_expression.RData data/19Q4_expression_join.RData
 depmap_stats: data/sd_threshold.Rds data/achilles_lower.Rds data/achilles_upper.Rds data/mean_virtual_achilles.Rds data/sd_virtual_achilles.Rds
 depmap_tables: data/master_top_table.RData data/master_bottom_table.RData
 depmap_pathways: data/master_positive.RData data/master_negative.RData
@@ -34,18 +34,18 @@ data/gene_summary.RData: code/create_gene_summary.R
 	@echo "Creating gene summary"
 	$(RSCRIPT_CMD) code/create_gene_summary.R --entrezkey ${ENTREZ_KEY}
 
-data/19Q3_achilles_cor.RData data/19Q3_achilles.RData data/19Q3_expression.RData data/19Q3_expression_id.RData data/19Q3_expression_join.RData: code/generate_depmap_data.R
+data/19Q4_achilles_cor.RData data/19Q4_achilles.RData data/19Q4_expression.RData data/19Q4_expression_join.RData: code/generate_depmap_data.R
 	@echo "Creating depmap data"
 	$(RSCRIPT_CMD) code/generate_depmap_data.R
 
-data/sd_threshold.Rds data/achilles_lower.Rds data/achilles_upper.Rds data/mean_virtual_achilles.Rds data/sd_virtual_achilles.Rds: data/19Q3_achilles_cor.RData code/generate_depmap_stats.R
+data/sd_threshold.Rds data/achilles_lower.Rds data/achilles_upper.Rds data/mean_virtual_achilles.Rds data/sd_virtual_achilles.Rds: data/19Q4_achilles_cor.RData code/generate_depmap_stats.R
 	@echo "Creating depmap stats"
 	$(RSCRIPT_CMD) code/generate_depmap_stats.R
 
-data/master_top_table.RData data/master_bottom_table.RData: code/generate_depmap_tables.R data/gene_summary.RData data/19Q3_achilles_cor.RData data/achilles_lower.Rds data/achilles_upper.Rds
+data/master_top_table.RData data/master_bottom_table.RData: code/generate_depmap_tables.R data/gene_summary.RData data/19Q4_achilles_cor.RData data/achilles_lower.Rds data/achilles_upper.Rds
 	@echo "Creating depmap tables"
 	$(RSCRIPT_CMD) code/generate_depmap_tables.R
 
-data/master_positive.RData data/master_negative.RData: code/generate_depmap_pathways.R data/gene_summary.RData data/gene_summary.RData data/19Q3_achilles_cor.RData data/achilles_lower.Rds data/achilles_upper.Rds
+data/master_positive.RData data/master_negative.RData: code/generate_depmap_pathways.R data/gene_summary.RData data/gene_summary.RData data/19Q4_achilles_cor.RData data/achilles_lower.Rds data/achilles_upper.Rds
 	@echo "Creating depmap pathways"
 	$(RSCRIPT_CMD) code/generate_depmap_pathways.R

--- a/openshift/file-list.json
+++ b/openshift/file-list.json
@@ -1,18 +1,18 @@
 {
     "items": [
         {
-            "dest": "/data/19Q3_achilles_cor.RData",
-            "source": "54985131-d8a4-4dd4-aa4e-9e4c81f74194",
+            "dest": "/data/19Q4_achilles_cor.RData",
+            "source": "57a1b833-ae01-4a1c-9d43-b2b672417891",
             "type": "DukeDS"
         },
         {
-            "dest": "/data/19Q3_expression.RData",
-            "source": "e5ab32f4-0b4f-4bdc-a3df-f54a5843c111",
+            "dest": "/data/19Q4_expression.RData",
+            "source": "9e0eeec7-f22f-4297-919b-6aad8c07f2ed",
             "type": "DukeDS"
         },
         {
-            "dest": "/data/19Q3_achilles.RData",
-            "source": "73aae91e-e554-4141-947c-4bf90320da2d",
+            "dest": "/data/19Q4_achilles.RData",
+            "source": "d287d655-8d6d-4fb5-bbe6-61ee5f971ef1",
             "type": "DukeDS"
         },
         {
@@ -26,18 +26,13 @@
             "type": "DukeDS"
         },
         {
-            "dest": "/data/19Q3_expression_id.RData",
-            "source": "8200b861-f1d4-4655-87b2-a71c5939f559",
-            "type": "DukeDS"
-        },
-        {
             "dest": "/data/achilles_lower.Rds",
             "source": "67dfea2e-9732-44c1-94db-879055c9cfb1",
             "type": "DukeDS"
         },
         {
-            "dest": "/data/19Q3_expression_join.RData",
-            "source": "fcdd0600-093d-459b-8967-c3c3116bac3c",
+            "dest": "/data/19Q4_expression_join.RData",
+            "source": "aa585a4f-04ee-475e-ae30-67b72bd4aee0",
             "type": "DukeDS"
         },
         {


### PR DESCRIPTION
## Makefile
Changes file names to use the 19Q4 versions instead of 19Q3.
Removes `expression_id.RData` from the Makefile since it is no longer created and used.

## openshift/file-list.json
Updates openshift data staging to stage the 19Q4_* files.
I also updated the IDs of these files to match the files in DukeDS.
Both these steps will need to be done every time we change the filenames.
If you have ddsclient installed you can easily see the list of IDs by running:
```
ddsclient list -p ddh-data -l | grep 19Q4
```

Fixes #23 
