### PR TITLE
rename genenames field synonyms to alias_symbols

### DIFF
--- a/code/create_gene_summary.R
+++ b/code/create_gene_summary.R
@@ -56,7 +56,7 @@ build_gene_summary <- function(gene_names_url, entrez_key) {
   gene_summary$locus_type <- str_replace(gene_summary$locus_type, "Rna", "RNA")
   gene_summary$approved_name <- str_to_sentence(gene_summary$approved_name)
   gene_summary %>%
-    unite("aka", previous_symbols:synonyms, sep = ", ", na.rm = TRUE)
+    unite("aka", previous_symbols:alias_symbols, sep = ", ", na.rm = TRUE)
 }
 
 create_gene_summary <- function(gene_names_url, entrez_key, gene_summary_output_path) {


### PR DESCRIPTION
Renames `synonyms` column to `alias_symbols` to match what is currently returned by genenames.org. This fixes a `object 'synonyms' not found` error when running `create_gene_summary.R`. 

Fixes #35
