### PR TITLE
adds separate volume to hold user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ misc/
 results/
 tmp/
 data/
+user-data/
 validation/
 doc/
 singularity/

--- a/code/app.R
+++ b/code/app.R
@@ -362,11 +362,12 @@ save_data <- function(input) {
   )
   
   #create dir
-  dir.create(file.path(here::here("data", "users")), showWarnings = FALSE)
+  directory_path <- here::here("user-data")
+  dir.create(file.path(directory_path), showWarnings = FALSE)
   # Write the file to the local system
   saveRDS(
     object = data,
-    file = file.path(here::here("data", "users"), file_name)
+    file = file.path(directory_path, file_name)
   )
 }
 

--- a/openshift/Deployment.yaml
+++ b/openshift/Deployment.yaml
@@ -42,10 +42,16 @@ items:
           volumeMounts:
           - mountPath: /srv/data
             name: ddh-data
+          - mountPath: /srv/user-data
+            name: ddh-user-data
         volumes:
         - name: ddh-data
+          readOnly: true
           persistentVolumeClaim:
             claimName: ddh-data-pvc
+        - name: ddh-user-data
+          persistentVolumeClaim:
+            claimName: ddh-user-data-pvc
     triggers:
     - imageChangeParams:
         automatic: true

--- a/openshift/Storage.yaml
+++ b/openshift/Storage.yaml
@@ -1,12 +1,27 @@
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    app: ddh
-  name: ddh-data-pvc
-spec:
-  accessModes:
-  - ReadWriteMany
-  resources:
-    requests:
-      storage: 5Gi
+items:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: ddh
+    name: ddh-data-pvc
+  spec:
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: 5Gi
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: ddh
+    name: ddh-user-data-pvc
+  spec:
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: 5Gi
+kind: List


### PR DESCRIPTION
Changes web app deployment to have two volumes:
- `data` - a read-only directory that contains generated data
- `user-data` - a directory where the web app can write user data files.

This is to prevent unintentional modification of the generated data by the web application.

Changes app.R to store user email/etc within the `user-data` directory instead of the `data/users` directory.

