### PR TITLE
Reduce memory requirements from 3G to 2G

### DIFF
--- a/openshift/Deployment.yaml
+++ b/openshift/Deployment.yaml
@@ -38,7 +38,7 @@ items:
             timeoutSeconds: 30
           resources:
             requests:
-              memory: 3G
+              memory: 2G
           volumeMounts:
           - mountPath: /srv/data
             name: ddh-data


### PR DESCRIPTION
Changes in PR #38 reduced the memory requirements of app.R. 
This change will allow running more instances(pods) of app.R
