### PR TITLE
lower memory request to 1G

### DIFF
--- a/openshift/Deployment.yaml
+++ b/openshift/Deployment.yaml
@@ -38,7 +38,7 @@ items:
             timeoutSeconds: 30
           resources:
             requests:
-              memory: 2G
+              memory: 1G
           volumeMounts:
           - mountPath: /srv/data
             name: ddh-data


### PR DESCRIPTION
Currently if we configure openshift to run two pods
for the website new deployments fail due to memory quotas.
This change will allow us to run two pods and gracefully
deploy new changes.

Based on openshift Memory metrics we are using ~ 1040 MiB.
This is just the requested amount and the app is allowed
to utilize more than this.