### PR TITLE
only use Rds files instead of RData files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ RSCRIPT_CMD ?= Rscript
 DOCKER_IMG ?= docker://dukegcb/ddh:latest
 
 # Defines the number intermediate pathway data files that will be created. This allow generating the pathway data in parallel.
-# Changing this number requires an update to the data/master_positive.RData and data/master_negative.RData rules below.
+# Changing this number requires an update to the data/master_positive.Rds and data/master_negative.Rds rules below.
 NUM_SUBSET_FILES ?= 10
 
 # Disable parallel build to handle code that creates multiple targets
@@ -27,11 +27,11 @@ clean_container:
 
 # Map simple target names to the files on which they depend
 container_image: singularity/ddh.sif
-gene_summary: data/gene_summary.RData
-depmap_data: data/19Q4_achilles_cor.RData data/19Q4_achilles.RData data/19Q4_expression.RData data/19Q4_expression.RData data/19Q4_expression_join.RData
+gene_summary: data/gene_summary.Rds
+depmap_data: data/19Q4_achilles_cor.Rds data/19Q4_achilles.Rds data/19Q4_expression.Rds data/19Q4_expression.Rds data/19Q4_expression_join.Rds
 depmap_stats: data/sd_threshold.Rds data/achilles_lower.Rds data/achilles_upper.Rds data/mean_virtual_achilles.Rds data/sd_virtual_achilles.Rds
-depmap_tables: data/master_top_table.RData data/master_bottom_table.RData
-depmap_pathways: data/master_positive.RData data/master_negative.RData
+depmap_tables: data/master_top_table.Rds data/master_bottom_table.Rds
+depmap_pathways: data/master_positive.Rds data/master_negative.Rds
 
 dirs:
 	mkdir -p data
@@ -41,27 +41,27 @@ singularity/ddh.sif:
 	@echo "Pulling container image"
 	singularity pull singularity/images/ddh.sif $(DOCKER_IMG)
 
-data/gene_summary.RData: code/create_gene_summary.R
+data/gene_summary.Rds: code/create_gene_summary.R
 	@echo "Creating gene summary"
 	$(RSCRIPT_CMD) code/create_gene_summary.R --entrezkey ${ENTREZ_KEY}
 
-data/19Q4_achilles_cor.RData data/19Q4_achilles.RData data/19Q4_expression.RData data/19Q4_expression_join.RData: code/generate_depmap_data.R
+data/19Q4_achilles_cor.Rds data/19Q4_achilles.Rds data/19Q4_expression.Rds data/19Q4_expression_join.Rds: code/generate_depmap_data.R
 	@echo "Creating depmap data"
 	$(RSCRIPT_CMD) code/generate_depmap_data.R
 
-data/sd_threshold.Rds data/achilles_lower.Rds data/achilles_upper.Rds data/mean_virtual_achilles.Rds data/sd_virtual_achilles.Rds: data/19Q4_achilles_cor.RData code/generate_depmap_stats.R
+data/sd_threshold.Rds data/achilles_lower.Rds data/achilles_upper.Rds data/mean_virtual_achilles.Rds data/sd_virtual_achilles.Rds: data/19Q4_achilles_cor.Rds code/generate_depmap_stats.R
 	@echo "Creating depmap stats"
 	$(RSCRIPT_CMD) code/generate_depmap_stats.R
 
-data/master_top_table.RData data/master_bottom_table.RData: code/generate_depmap_tables.R data/gene_summary.RData data/19Q4_achilles_cor.RData data/achilles_lower.Rds data/achilles_upper.Rds
+data/master_top_table.Rds data/master_bottom_table.Rds: code/generate_depmap_tables.R data/gene_summary.Rds data/19Q4_achilles_cor.Rds data/achilles_lower.Rds data/achilles_upper.Rds
 	@echo "Creating depmap tables"
 	$(RSCRIPT_CMD) code/generate_depmap_tables.R
 
-data/master_positive.RData: code/generate_pathways.sh code/generate_depmap_pathways.R code/merge_depmap_pathways.R
+data/master_positive.Rds: code/generate_pathways.sh code/generate_depmap_pathways.R code/merge_depmap_pathways.R
 	@echo "Creating positive pathways data"
 	RSCRIPT_CMD="$(RSCRIPT_CMD)" PATHWAY_TYPE=positive NUM_SUBSET_FILES=$(NUM_SUBSET_FILES) ./code/generate_pathways.sh
 
-data/master_negative.RData: code/generate_pathways.sh code/generate_depmap_pathways.R code/merge_depmap_pathways.R
+data/master_negative.Rds: code/generate_pathways.sh code/generate_depmap_pathways.R code/merge_depmap_pathways.R
 	@echo "Creating negative pathways data"
 	RSCRIPT_CMD="$(RSCRIPT_CMD)" PATHWAY_TYPE=negative NUM_SUBSET_FILES=$(NUM_SUBSET_FILES) ./code/generate_pathways.sh
 

--- a/code/app.R
+++ b/code/app.R
@@ -20,11 +20,11 @@ library(DT)
 source(here::here("code", "current_release.R"))
 
 #read data from create_gene_summary.R
-load(here::here("data", "gene_summary.RData"))
+gene_summary <- readRDS(here::here("data", "gene_summary.Rds"))
      
 #read data from generate_depmap_data.R
-load(file=here::here("data", paste0(release, "_achilles.RData")))
-load(file=here::here("data", paste0(release, "_expression_join.RData")))
+achilles <- readRDS(file=here::here("data", paste0(release, "_achilles.Rds")))
+expression_join <- readRDS(file=here::here("data", paste0(release, "_expression_join.Rds")))
 
 #read data from generate_depmap_stats.R
 sd_threshold <- readRDS(file = here::here("data", "sd_threshold.Rds"))
@@ -34,10 +34,10 @@ mean_virtual_achilles <- readRDS(file = here::here("data", "mean_virtual_achille
 sd_virtual_achilles <- readRDS(file = here::here("data", "sd_virtual_achilles.Rds"))
 
 #read data from generate_depmap_pathways.R
-load(file=here::here("data", "master_bottom_table.RData"))
-load(file=here::here("data", "master_top_table.RData"))
-load(file=here::here("data", "master_positive.RData"))
-load(file=here::here("data", "master_negative.RData"))
+master_bottom_table <- readRDS(file=here::here("data", "master_bottom_table.Rds"))
+master_top_table <- readRDS(file=here::here("data", "master_top_table.Rds"))
+master_positive <- readRDS(file=here::here("data", "master_positive.Rds"))
+master_negative <- readRDS(file=here::here("data", "master_negative.Rds"))
 
 #FUNCTIONS-----
 gene_summary_details <- function(gene_summary) {

--- a/code/create_gene_summary.R
+++ b/code/create_gene_summary.R
@@ -6,7 +6,7 @@ library(rentrez)
 library(feather)
 
 gene_names_url <- "https://www.genenames.org/cgi-bin/download/custom?col=gd_hgnc_id&col=gd_app_sym&col=gd_app_name&col=gd_prev_sym&col=gd_aliases&col=gd_pub_chrom_map&col=gd_pub_refseq_ids&col=md_eg_id&col=gd_locus_type&col=md_mim_id&col=md_prot_id&status=Approved&hgnc_dbtag=on&order_by=gd_app_sym_sort&format=text&submit=submit"
-gene_summary_output_filename <- "gene_summary.RData"
+gene_summary_output_filename <- "gene_summary.Rds"
 fetch_batch_size <- 100   # batch size of 500 was too high. 200 worked, using 100 as reasonable default
 
 # returns a data frame based on gene_names_url and summaries from entrez "gene" database.
@@ -61,7 +61,7 @@ build_gene_summary <- function(gene_names_url, entrez_key) {
 
 create_gene_summary <- function(gene_names_url, entrez_key, gene_summary_output_path) {
   gene_summary = build_gene_summary(gene_names_url, entrez_key)
-  save(gene_summary, file = gene_summary_output_path)
+  saveRDS(gene_summary, file = gene_summary_output_path)
 }
 
 # Command line argument parser that will let a user optionally specify:

--- a/code/generate_depmap_data.R
+++ b/code/generate_depmap_data.R
@@ -17,7 +17,7 @@ achilles_raw <- read_csv(achilles_url, col_names = TRUE) %>%
   `colnames<-`(str_remove_all(names(.), "\\s\\(\\d+\\)"))
 
 #add name cleaning step
-load(file = here::here("data", "gene_summary.RData"))
+gene_summary <- readRDS(file = here::here("data", "gene_summary.Rds"))
 source(here::here("code", "fix_names.R"))
 achilles <- clean_colnames(achilles_raw)
 
@@ -69,10 +69,10 @@ achilles_cor <- achilles %>%
   correlate() #(diagonal = 0) set to 0 so easy to summarize, but should be NA; so added na.rm = TRUE to fun() in EDA
 
 #save files
-save(achilles, file = here::here("data", paste0(release, "_achilles.RData")))
-save(expression, file = here::here("data", paste0(release, "_expression.RData")))
-save(expression_join, file = here::here("data", paste0(release, "_expression_join.RData")))
-save(achilles_cor, file = here::here("data", paste0(release, "_achilles_cor.RData")))
+saveRDS(achilles, file = here::here("data", paste0(release, "_achilles.Rds")))
+saveRDS(expression, file = here::here("data", paste0(release, "_expression.Rds")))
+saveRDS(expression_join, file = here::here("data", paste0(release, "_expression_join.Rds")))
+saveRDS(achilles_cor, file = here::here("data", paste0(release, "_achilles_cor.Rds")))
 
 #how long
 time_end_data <- Sys.time()

--- a/code/generate_depmap_pathways.R
+++ b/code/generate_depmap_pathways.R
@@ -50,8 +50,8 @@ get_gene_names_to_process <- function(subset_file_idx, num_subset_files, achille
 }
 
 read_input_data <- function() {
-  load(file = here::here("data", "gene_summary.RData"))
-  load(file = here::here("data", paste0(release, "_achilles_cor.RData")))
+  gene_summary <- readRDS(file = here::here("data", "gene_summary.Rds"))
+  achilles_cor <- readRDS(file = here::here("data", paste0(release, "_achilles_cor.Rds")))
   achilles_lower <- readRDS(file = here::here("data", "achilles_lower.Rds"))
   achilles_upper <- readRDS(file = here::here("data", "achilles_upper.Rds"))
   

--- a/code/generate_depmap_pathways.R
+++ b/code/generate_depmap_pathways.R
@@ -149,6 +149,7 @@ create_pathway_subset_file <- function(pathways_type, subset_file_idx, num_subse
   message("Generating data for pathways ", pathways_type, " subset ", subset_file_idx, ".")
   input_data <- read_input_data()
   gene_group <- get_gene_names_to_process(subset_file_idx, num_subset_files, input_data$achilles_cor)
+  gene_group <- head(gene_group, n=100)
   message("Processing ", length(gene_group), " genes.")
   if (pathways_type == dpu_pathways_positive_type) {
     subset_data <- generate_positive_data(gene_group, input_data$achilles_cor, input_data$achilles_upper, input_data$gene_summary)

--- a/code/generate_depmap_pathways.R
+++ b/code/generate_depmap_pathways.R
@@ -149,7 +149,6 @@ create_pathway_subset_file <- function(pathways_type, subset_file_idx, num_subse
   message("Generating data for pathways ", pathways_type, " subset ", subset_file_idx, ".")
   input_data <- read_input_data()
   gene_group <- get_gene_names_to_process(subset_file_idx, num_subset_files, input_data$achilles_cor)
-  gene_group <- head(gene_group, n=100)
   message("Processing ", length(gene_group), " genes.")
   if (pathways_type == dpu_pathways_positive_type) {
     subset_data <- generate_positive_data(gene_group, input_data$achilles_cor, input_data$achilles_upper, input_data$gene_summary)

--- a/code/generate_depmap_stats.R
+++ b/code/generate_depmap_stats.R
@@ -11,7 +11,7 @@ time_begin_stats <- Sys.time()
 source(here::here("code", "current_release.R"))
 
 #LOAD data 
-load(file = here::here("data", paste0(release, "_achilles_cor.RData")))
+achilles_cor <- readRDS(file = here::here("data", paste0(release, "_achilles_cor.Rds")))
 
 #convert cor
 class(achilles_cor) <- c("cor_df", "tbl_df", "tbl", "data.frame")

--- a/code/generate_depmap_tables.R
+++ b/code/generate_depmap_tables.R
@@ -12,8 +12,8 @@ time_begin_tables <- Sys.time()
 source(here::here("code", "current_release.R"))
 
 #LOAD data 
-load(file = here::here("data", "gene_summary.RData"))
-load(file = here::here("data", paste0(release, "_achilles_cor.RData")))
+gene_summary <- readRDS(file = here::here("data", "gene_summary.Rds"))
+achilles_cor <- readRDS(file = here::here("data", paste0(release, "_achilles_cor.Rds")))
 achilles_lower <- readRDS(file = here::here("data", "achilles_lower.Rds"))
 achilles_upper <- readRDS(file = here::here("data", "achilles_upper.Rds"))
 
@@ -80,8 +80,8 @@ for (fav_gene in gene_group) {
 }
 
 #save
-save(master_top_table, file=here::here("data", "master_top_table.RData"))
-save(master_bottom_table, file=here::here("data", "master_bottom_table.RData"))
+saveRDS(master_top_table, file=here::here("data", "master_top_table.Rds"))
+saveRDS(master_bottom_table, file=here::here("data", "master_bottom_table.Rds"))
 
 #how long
 time_end_tables <- Sys.time()

--- a/code/generate_pathways.sh
+++ b/code/generate_pathways.sh
@@ -3,8 +3,8 @@
 # This is done by creating subset files in parallel and then merging them together.
 # Environment variables:
 # PATHWAY_TYPE determines the pathway file to be created:
-#  "positive" ->  master_positive.RData
-#  "negative" ->  master_negative.RData
+#  "positive" ->  master_positive.Rds
+#  "negative" ->  master_negative.Rds
 # RSCRIPT_CMD specifies RScript to run
 # NUM_SUBSET_FILES specifies number of subset files to create
 set -e

--- a/code/merge_depmap_pathways.R
+++ b/code/merge_depmap_pathways.R
@@ -11,8 +11,8 @@ library(optparse)
 #read dpu_* methods for getting subset filenames and parsing command line parameters
 source(here::here("code", "depmap_pathways_util.R"))
 
-master_positive_filename <- "master_positive.RData"
-master_negative_filename <- "master_negative.RData"
+master_positive_filename <- "master_positive.Rds"
+master_negative_filename <- "master_negative.Rds"
 
 merge_pathways_rds_files <- function(subset_filepaths) {
   merged_data <- tibble(
@@ -30,13 +30,13 @@ merge_pathways_rds_files <- function(subset_filepaths) {
 save_master_positive <- function(subset_filepaths) {
   master_positive <- merge_pathways_rds_files(subset_filepaths)
   message("Saving master_positive to ", master_positive_filename)
-  save(master_positive, file=here::here("data", master_positive_filename))
+  saveRDS(master_positive, file=here::here("data", master_positive_filename))
 }
 
 save_master_negative <- function(subset_filepaths) {
   master_negative <- merge_pathways_rds_files(subset_filepaths)
   message("Saving master_negative to ", master_negative_filename)
-  save(master_negative, file=here::here("data", master_negative_filename))
+  saveRDS(master_negative, file=here::here("data", master_negative_filename))
 }
 
 main <- function() {

--- a/code/methods.Rmd
+++ b/code/methods.Rmd
@@ -26,12 +26,12 @@ source(here::here("code", "current_release.R"))
 
 ##LOAD DATA
 fav_gene <- "TP53"
-load(file = here::here("data", "gene_summary.RData"))
-load(file = here::here("data", paste0(release, "_achilles.Rdata")))
-load(file = here::here("data", paste0(release, "_achilles_cor.Rdata")))
+gene_summary <- readRDS(file = here::here("data", "gene_summary.Rds"))
+achilles <- readRDS(file = here::here("data", paste0(release, "_achilles.Rds")))
+achilles_cor <- readRDS(file = here::here("data", paste0(release, "_achilles_cor.Rds")))
 class(achilles_cor) <- c("cor_df", "tbl_df", "tbl", "data.frame")
-load(file = here::here("data", paste0(release, "_expression.Rdata")))
-load(file = here::here("data", paste0(release, "_expression_join.RData")))
+expression <- readRDS(file = here::here("data", paste0(release, "_expression.Rds")))
+expression_join <- readRDS(file = here::here("data", paste0(release, "_expression_join.Rds")))
 
 #LOAD STATS
 sd_threshold <- readRDS(file = here::here("data", "sd_threshold.rds"))


### PR DESCRIPTION
Previously we had a mixture of RData files (which support holding multiple items) and Rds files all of which only hold a single item. When you load an RData file the names of the items loaded are not explicit and you must consult where the RData file was created. With Rds files you assign a name to the loaded object(data frame) directly.

Fixes #46 

NOTES: 
- I did not update the scripts in `/code/eda` as is our current practice
- Once this is merged the [openshift/file-list.json](https://github.com/hirscheylab/ddh/blob/master/openshift/file-list.json) file will need to be regenerated

Example data generated using this branch is in DukeDS under project [ddh-test-data](https://dataservice.duke.edu/#/project/223c5b94-dacb-4316-8327-ba61a9e63160).