### PR TITLE
create reports in the background

### DIFF
--- a/base-shiny/Dockerfile
+++ b/base-shiny/Dockerfile
@@ -18,7 +18,9 @@ RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE \
  viridis \
  pander \
  DT \
- ggraph
+ ggraph \
+ future \
+ promises
 
 COPY ./shiny-server.conf /etc/shiny-server/shiny-server.conf
 RUN chown -R shiny /var/lib/shiny-server/

--- a/code/app.R
+++ b/code/app.R
@@ -357,8 +357,8 @@ render_complete_report <- function (file, gene_symbol) {
   flat_bottom_complete <- make_enrichment_table(master_negative, gene_symbol)
   graph_report <- make_graph_report(gene_symbol)
   rmarkdown::render("report_depmap_app.Rmd", output_file = file)
-}
 
+}
 render_dummy_report <- function (file, gene_symbol) {
   fav_gene_summary <- gene_summary %>%
     filter(approved_symbol == gene_symbol)
@@ -389,6 +389,7 @@ save_data <- function(input) {
   # Write the file to the local system as csv without column headers for ease of use
   write_csv(data, path=file.path(directory_path, file_name), col_names=FALSE)
 }
+
 
 
 #UI------

--- a/code/app.R
+++ b/code/app.R
@@ -18,7 +18,7 @@ library(future)
 library(promises)
 
 render_report_in_background <- FALSE
-if (future::supportsMulticore()) {
+if (supportsMulticore()) {
   plan(multicore)
   render_report_in_background <- TRUE
 }

--- a/code/app.R
+++ b/code/app.R
@@ -565,10 +565,6 @@ server <- function(input, output, session) {
       withProgress(message = "Building your shiny report", detail = "Patience, young grasshopper", value = 1, {
         if (render_report_in_background) {
           future({
-            # Reload current_release to prevent error in `setup` block in report_*.Rmd
-            # the Rmd files cannot locate the code directory due to them being run in a temp directory
-            # I think the current version just happens to work since this file is loaded and cached in memory.
-            source(here::here("code", "current_release.R"), local=TRUE)
             render_report_to_file(file, gene_symbol)
           })
         } else {


### PR DESCRIPTION
Changes the shiny app to create reports in the background when the parallel processing `multicore` plan is supported. When this app is deployed this will allow the app to be responsive to multiple users while reports are being created. 

When the `multicore` plan is not supported reports will continue to be created in the foreground. This is to allow continued development changes via RStudio(which doesn't support the `multicore` plan).

These changes also reworked the progress bar to accommodate background processing.

I tested this functionality with two browser windows. I was able to navigate the website in one while the other was generating a report.

Note: In testing the `multisession` parallel processing plan supported by RStudio I found that it spent a really long time passing data to the background process. This added about 2 minutes to the time it took to render a report.


