### PR TITLE
Adds deployment to redirect http://ddh.org -> https://www.ddh.org

### DIFF
--- a/openshift/Redirect.yaml
+++ b/openshift/Redirect.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  data:
+    redirect.conf: |
+      Options +FollowSymLinks
+      RewriteEngine on
+      RewriteRule (.*) https://www.datadrivenhypothesis.org/ [R=301,L]
+  kind: ConfigMap
+  metadata:
+    name: redirect-conf
+- apiVersion: v1
+  image:
+    dockerImageLayers: null
+    dockerImageMetadata:
+      ContainerConfig: {}
+      Created: null
+      Id: ""
+      apiVersion: "1.0"
+      kind: DockerImage
+    dockerImageMetadataVersion: "1.0"
+    metadata:
+      creationTimestamp: null
+  kind: ImageStreamTag
+  lookupPolicy:
+    local: false
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ddh-httpd-redirect
+    name: httpd:2.4
+  tag:
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/httpd:2.4
+    generation: null
+    importPolicy: {}
+    name: "2.4"
+    referencePolicy:
+      type: ""
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: ddh-httpd-redirect
+    name: ddh-httpd-redirect
+  spec:
+    replicas: 1
+    selector:
+      app: ddh-httpd-redirect
+      deploymentconfig: ddh-httpd-redirect
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: ddh-httpd-redirect
+          deploymentconfig: ddh-httpd-redirect
+      spec:
+        containers:
+        - image: docker-registry.default.svc:5000/openshift/httpd:2.4
+          name: httpd
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          volumeMounts:
+          - name: redirect-conf
+            mountPath: "/etc/httpd/conf.d/redirect.conf"
+            readOnly: true
+            subPath: "redirect.conf"
+        volumes:
+        - name: redirect-conf
+          configMap:
+            name: redirect-conf
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - httpd
+        from:
+          kind: ImageStreamTag
+          name: httpd:2.4
+          namespace: openshift
+      type: ImageChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ddh-httpd-redirect
+    name: ddh-httpd-redirect-service
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: ddh-httpd-redirect
+      deploymentconfig: ddh-httpd-redirect
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: ddh-httpd-redirect
+    name: ddh-httpd-redirect-route
+  spec:
+    host: datadrivenhypothesis.org
+    path: /
+    to:
+      kind: Service
+      name: ddh-httpd-redirect-service
+kind: List
+metadata: {}


### PR DESCRIPTION
Began with `oc new-app httpd --dry-run=True -o yaml > Redirect.yaml`

This provided an ImageStreamTag for the httpd image, pulled from the internal openshift docker registry, a DeploymentConfig to run a pod for it, and a service for incoming traffic.

I layered on a simple redirect config file to mount at /etc/httpd/conf.d/redirect.conf and added a route to accept traffic at http://datadrivenhypothesis.org

I started with nginx but wanted to keep it simple, and the provided nginx images are all s2i builds.

This is in-place now, so visiting http://datadrivenhypothesis.org/ will redirect you to the https site.

Fixes #66 