### PR TITLE
add ggplot2 to install2.r command

### DIFF
--- a/base-shiny/Dockerfile
+++ b/base-shiny/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Dan Leehr <dan.leehr@duke.edu>"
 RUN apt-get update && apt-get install -y texlive-xetex
 
 RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE \
+ ggplot2 \
  here \
  corrr  \
  lubridate \


### PR DESCRIPTION
Installs a recent version of ggplot2 to fix the following error in deployment:
> Error in expansion: could not find function "expansion"