### PR TITLE
Pathways search

### DIFF
--- a/code/app.R
+++ b/code/app.R
@@ -456,7 +456,6 @@ server <- shinyServer(function(input, output, session) {
     updateQueryString(paste0("?show=search&query=", input$gene_or_pathway), mode="push")
   })
   
-  # the below item is problematic for the back button
   search_callback(input, output, session)
   gene_callback(input, output, session)
 })

--- a/code/app.R
+++ b/code/app.R
@@ -120,11 +120,10 @@ gene_summary_details <- function(gene_summary) {
 
 pathway_summary_details <- function(pathways_row) {
   gene_symbols <- lapply(pathways_row$data, function(x) { paste(x$gene, collapse=', ') })
-  title <- paste0(pathways_row$pathway, "(", pathways_row$go, ")")
+  title <- paste0("Pathway:", pathways_row$pathway, "(", pathways_row$go, ")")
   list(
     h4(
-      tags$strong("Pathway:"),
-      tags$a(title, href=paste0("?show=detail&content=pathway&go=", pathways_row$go))
+      tags$strong(title),
     ),
     tags$dl(
       tags$dt("Genes"),

--- a/code/app.R
+++ b/code/app.R
@@ -64,18 +64,44 @@ search_panel <- function() {
   )
 }
 
-gene_search_results <- function(gene_summary_row) {
+query_result_row <- function(row) {
+  if (row$contents == 'gene') {
+    gene_query_result_row(row)
+  } else {
+    pathway_query_result_row(row)
+  }
+}
+
+gene_query_result_row <- function(row) {
+  gene_summary_row <- row$data
   title <- paste0(gene_summary_row["approved_symbol"], ": ", gene_summary_row["approved_name"])
   list(
-    div(
-      tags$a(title, href=paste0("?show=gene&symbol=", gene_summary_row["approved_symbol"]))
-    ),
-    div(tags$strong("Aka:"), gene_summary_row["aka"]),
-    div(tags$strong("Entrez ID:"), gene_summary_row["ncbi_gene_id"]),
-    hr()
+   h4(
+     tags$strong("Gene:"),
+     tags$a(title, href=paste0("?show=detail&content=gene&symbol=", gene_summary_row["approved_symbol"]))
+   ),
+   div(tags$strong("Aka:"), gene_summary_row["aka"]),
+   div(tags$strong("Entrez ID:"), gene_summary_row["ncbi_gene_id"]),
+   hr()
   )
 }
 
+pathway_query_result_row <- function(row) {
+  pathways_row <- row$data
+  gene_symbols <- lapply(pathways_row$data, function(x) { paste(x$gene, collapse=', ') })
+  title <- paste0(pathways_row$pathway, "(", pathways_row$go, ")")
+  list(
+    h4(
+      tags$strong("Pathway:"),
+      tags$a(title, href=paste0("?show=detail&content=pathway&go=", pathways_row$go))
+    ),
+    tags$dl(
+      tags$dt("Genes"),
+      tags$dd(gene_symbols),
+    ),
+    hr()
+  )
+}
 
 gene_summary_details <- function(gene_summary) {
   title <- paste0(gene_summary$approved_symbol, ": ", gene_summary$approved_name)
@@ -92,20 +118,21 @@ gene_summary_details <- function(gene_summary) {
   )
 }
 
-#pathway_summary_details <- function(gene_summary) {
-#  title <- paste0(pathways$pathway, ": ", gene_summary$approved_name)
-#  tagList(
-#    h3(title),
-#    h4("Summary"),
-#    tags$dl(
-#      tags$dt("Gene"), tags$dd(gene_summary$approved_symbol),
-#      tags$dt("Name"), tags$dd(gene_summary$approved_name),
-#      tags$dt("aka"), tags$dd(gene_summary$aka),
-#      tags$dt("Entrez ID"), tags$dd(gene_summary$ncbi_gene_id),
-#      tags$dt("Gene Summary"), tags$dd(gene_summary$entrez_summary)
-#    )
-#  )
-#}
+pathway_summary_details <- function(pathways_row) {
+  gene_symbols <- lapply(pathways_row$data, function(x) { paste(x$gene, collapse=', ') })
+  title <- paste0(pathways_row$pathway, "(", pathways_row$go, ")")
+  list(
+    h4(
+      tags$strong("Pathway:"),
+      tags$a(title, href=paste0("?show=detail&content=pathway&go=", pathways_row$go))
+    ),
+    tags$dl(
+      tags$dt("Genes"),
+      tags$dd(gene_symbols),
+    ),
+    hr()
+  )
+}
 
 #gene_summary_not_found <- function(gene_symbol) {
 #  if(sum(str_detect(gene_summary$aka, paste0("(?<![:alnum:])", gene_symbol, "(?![:alnum:]|\\-)"))) > 0) {
@@ -130,6 +157,12 @@ gene_summary_ui <- function(gene_symbol) {
 #    }
   }
   result
+}
+
+pathway_summary_ui <- function(pathway_go) {
+  pathway_row <- pathways %>%
+    filter(go == pathway_go)
+  pathway_summary_details(pathway_row)
 }
 
 render_report_to_file <- function(file, gene_symbol) {
@@ -237,19 +270,19 @@ search_page <- tagList(
   navbarPage(title = main_title),
   div(search_panel(), style="float: right"),
   h3(textOutput("search_title")),
-  div(div(h3("Gene", class="panel-title"), class="panel-heading"),
+  div(div(h3("Results", class="panel-title"), class="panel-heading"),
       div(uiOutput("genes_search_result"), class="panel-body"),
       class="bg-info panel panel-default"
   )
 )
 
-### SEARCH RESULT
-gene_page <- fluidPage(
+### DETAILS PAGE: shows either gene or pathway data
+detail_page <- fluidPage(
   head_tags,
   navbarPage(title = main_title,
     tabPanel("Home",
              div(search_panel(), style="float: right"),
-             uiOutput("gene_summary")
+             uiOutput("detail_summary")
     ),
     navbarMenu(title = "Cell Dependencies",
                tabPanel("Plots",
@@ -316,8 +349,17 @@ gene_page <- fluidPage(
 
 gene_callback <- function(input, output, session) {
   data <- reactive({
-    gene_symbol <- getQueryString()$symbol
-    if_else(str_detect(gene_symbol, "orf"), gene_symbol, str_to_upper(gene_symbol))
+    content <- getQueryString()$content
+    if (content == 'gene') {
+      gene_symbol <- getQueryString()$symbol
+      if_else(str_detect(gene_symbol, "orf"), gene_symbol, str_to_upper(gene_symbol))
+    } else {
+      pathway_go <- getQueryString()$go
+      pathway_row <- pathways %>%
+        filter(go == pathway_go)
+      # pathway_row$data[[1]]$gene
+      pathway_row$data[[1]]$gene[[1]]  # TODO remove this line and uncomment the above line
+    }
   })
 
   # When the Submit button is clicked, save the form data
@@ -332,9 +374,14 @@ gene_callback <- function(input, output, session) {
   output$text_dep_bottom <- renderText({paste0("Genes with inverse dependencies as ", data())})
   output$text_neg_enrich <- renderText({paste0("Pathways of genes with inverse dependencies as ", data())})
 
-  output$gene_summary <- renderUI({
-    # render details about the gene symbol user entered
-    gene_summary_ui(data())
+  output$detail_summary <- renderUI({
+    content <- getQueryString()$content
+    if (content == 'gene') {
+      gene_summary_ui(data())
+    } else {
+      pathway_summary_ui(getQueryString()$go) 
+    }
+    # render details about the gene symbol or pathway user chose
   })
   output$dep_top <- DT::renderDataTable({
     validate(
@@ -425,7 +472,7 @@ ui <- shinyUI(
 pages_ui <- list(
   home=home_page,
   search=search_page,
-  gene=gene_page
+  detail=detail_page
 )
 
 search_callback <- function(input, output, session) {
@@ -435,10 +482,13 @@ search_callback <- function(input, output, session) {
   })
   output$genes_search_result <- renderUI({
     query <- getQueryString()
-    selected_genes <- gene_summary %>%
-      filter(str_detect(approved_symbol, paste0("^", query$query))) %>%
-      head(10)
-    apply(selected_genes, 1, gene_search_results)
+    query_results_table <- make_query_results_table(gene_summary, pathways, query$query)
+    if (nrow(query_results_table) > 0) {
+      apply(query_results_table, 1, query_result_row)
+    }
+    else {
+      "No results found."
+    }
   })
 }
 

--- a/code/fun_tables.R
+++ b/code/fun_tables.R
@@ -75,5 +75,6 @@ make_query_results_table <- function(gene_summary, pathways, query_str, limit_pa
     group_by(key, title, contents) %>%
     nest()
 
-  return (bind_rows(genes_data, pathways_data))
+  bind_rows(genes_data, pathways_data) %>%
+    arrange(title)
 }

--- a/code/fun_tables.R
+++ b/code/fun_tables.R
@@ -44,8 +44,8 @@ make_achilles_table <- function(data_table, expression_table, gene_symbol) {
 make_query_results_table <- function(gene_summary, pathways, query_str, limit_pathways=10, limit_genes=10) {
   # Searches for query_str in gene_summary and pathways and limits the number of rows returned from each.
   # Returns df with columns:
-  # - key - pathways$pathway or gene_summary$approved_name
-  # - title - pathways$go or gene_summary$approved_symbol
+  # - key - pathways$go or gene_summary$approved_symbol
+  # - title - pathways$pathway or gene_summary$approved_name
   # - contents - 'pathway' or 'gene'
   # - data - variables from a single row of pathways or gene_summary
 


### PR DESCRIPTION
These changes allow searching genes and pathways.

## Search/combine gene_summary.Rds and pathways.Rds
Adds [make_query_results_table](https://github.com/Duke-GCB/ddh/blob/bc41d4c429d347d1ae6d1f1a6c108dec0c5e47b3/code/fun_tables.R#L44-L79) function in fun_tables.R that searches both `gene_summary` and `pathways` and returns data used to show search results:
```
make_query_results_table <- function(gene_summary, pathways, query_str, limit_pathways=10, limit_genes=10) {
  # Searches for query_str in gene_summary and pathways and limits the number of rows returned from each.
  # Returns df with columns:
  # - key - pathways$go or gene_summary$approved_symbol
  # - title - pathways$pathway or gene_summary$approved_name
  # - contents - 'pathway' or 'gene'
  # - data - variables from a single row of pathways or gene_summary
...
}
```

**Sorting** - The search results are sorted by `title`. Looking for feedback since this means an exact match of a gene symbol might not be the first item in the list.
**Limiting** - Right now we just stop after looking for 10 genes and 10 pathways. This feels a little awkward.

## Query Param changes
Renamed `gene_page` to `detail_page` so the pages are now `home`, `search`, and `detail`.
Adds `content` parameter that is either 'gene' or 'pathway'.
The `symbol` query parameter is used to specify the the gene to show when `content=gene`.
The `go` query parameter is used to specify the the pathway to show when `content=pathway`.

Examples query params:
- `..?show=detail&content=gene&symbol=C2CD2` - view gene symbol `C2CD2`
- `...?show=detail&content=pathway&go=0060315` - view pathway with go `0060315`

**Simplify Query Params** - We could just keep show=gene and show=pathway and avoid the `content` param if that would be clearer.

## Search Result UI Changes
Each row returned by `make_query_results_table` will be converted to HTML using `query_result_row` which will call either `gene_query_result_row` or `pathway_query_result_row `:

![Screen Shot 2020-04-19 at 1 32 50 PM](https://user-images.githubusercontent.com/1024463/79695025-4d075500-8242-11ea-8f0e-48b1fae61b62.png)

## Detail Summary Changes
For a gene the detail summary is visually the same.
For pathway the screen looks like so:
<img width="876" alt="Screen Shot 2020-04-19 at 1 15 07 PM" src="https://user-images.githubusercontent.com/1024463/79694673-dcf7cf80-823f-11ea-86e2-5221cd58e5ee.png">

**Pathway Detail Page Shows One Gene**
In this branch the `data()` function only returns the first gene to keep the other tabs functional.
Code to undo this limitation:
https://github.com/Duke-GCB/ddh/blob/bc41d4c429d347d1ae6d1f1a6c108dec0c5e47b3/code/app.R#L360-L361


## Unrelated fix
Removed outdated comment related to back button not working. This has already been fixed. The problem was not limiting the search so when searching for blank it hung the app.

