### PR TITLE
search genes symbol, aka, then approved name

### DIFF
--- a/code/fun_tables.R
+++ b/code/fun_tables.R
@@ -62,12 +62,23 @@ make_query_results_table <- function(gene_summary, pathways, query_str, limit_pa
     group_by(key, title, contents) %>%
     nest()
 
-  # find gene data and nest it underneath generic key, title, and contents columns
-  genes_data <- gene_summary %>%
-    filter(
-      str_detect(approved_symbol, find_word_start_regex) |
-        str_detect(approved_name, find_word_start_regex) |
-        str_detect(aka, find_word_start_regex)) %>%
+  # find genes most specific
+  genes_data_symbol <- gene_summary %>%
+    filter(str_detect(approved_symbol, find_word_start_regex)) %>%
+    head(limit_genes)
+
+  # find genes most likely alternative
+  genes_data_aka <- gene_summary %>%
+    filter(str_detect(aka, find_word_start_regex)) %>%
+    head(limit_genes)
+
+  # find genes most generic
+  genes_data_name <- gene_summary %>%
+    filter(str_detect(approved_name, find_word_start_regex)) %>%
+    head(limit_genes)
+
+  # nest gene data underneath generic key, title, and contents columns
+  genes_data <- bind_rows(genes_data_symbol, genes_data_aka, genes_data_name) %>%
     head(limit_genes) %>%
     mutate(key = approved_symbol) %>%
     mutate(title = approved_name) %>%
@@ -75,6 +86,5 @@ make_query_results_table <- function(gene_summary, pathways, query_str, limit_pa
     group_by(key, title, contents) %>%
     nest()
 
-  bind_rows(genes_data, pathways_data) %>%
-    arrange(title)
+  bind_rows(genes_data, pathways_data)
 }


### PR DESCRIPTION
Implements suggestion from #79

Removes sorting from query_results table. Pathways will follow genes.
Gene symbol will be searched first, then aka, then approved name.

