### PR TITLE
Make gene search results unique

### DIFF
--- a/code/fun_tables.R
+++ b/code/fun_tables.R
@@ -78,7 +78,7 @@ make_query_results_table <- function(gene_summary, pathways, query_str, limit_pa
     head(limit_genes)
 
   # nest gene data underneath generic key, title, and contents columns
-  genes_data <- bind_rows(genes_data_symbol, genes_data_aka, genes_data_name) %>%
+  genes_data <- unique(bind_rows(genes_data_symbol, genes_data_aka, genes_data_name)) %>%
     head(limit_genes) %>%
     mutate(key = approved_symbol) %>%
     mutate(title = approved_name) %>%


### PR DESCRIPTION
Fixes `make_query_results_table` so there will be no duplicated rows.
Duplicate rows caused problems rendering the HTML.
This change is to fix the error mentioned here:
https://github.com/matthewhirschey/ddh/issues/79#issuecomment-617760476
This problem seems to occur for genes that have their symbol in their approved_name. 
For example the approved name of `MDM2` is `Mdm2 proto-oncogene`.