### PR TITLE
Allow users to enter a custom gene list

### DIFF
--- a/code/app.R
+++ b/code/app.R
@@ -407,21 +407,27 @@ detail_page <- fluidPage(
 
 #SERVER-----
 
+detail_page_visible <- function() {
+  getQueryString()$show == 'detail'
+}
+
 gene_callback <- function(input, output, session) {
   data <- reactive({
-    content <- getQueryString()$content
-    if (content == 'gene') {
-      gene_symbol <- getQueryString()$symbol
-      if_else(str_detect(gene_symbol, "orf"), gene_symbol, str_to_upper(gene_symbol))
-    } else {
-      pathway_gene_list <- getQueryString()$gene_list
-      if (!is.null(pathway_gene_list)) {
-        c(str_split(pathway_gene_list, "\\s*,\\s*", simplify = TRUE))
+    if (detail_page_visible()) {
+      content <- getQueryString()$content
+      if (content == 'gene') {
+        gene_symbol <- getQueryString()$symbol
+        if_else(str_detect(gene_symbol, "orf"), gene_symbol, str_to_upper(gene_symbol))
       } else {
-        pathway_go <- getQueryString()$go
-        pathway_row <- pathways %>%
-          filter(go == pathway_go)
-        pathway_row$data[[1]]$gene        
+        pathway_gene_list <- getQueryString()$gene_list
+        if (!is.null(pathway_gene_list)) {
+          c(str_split(pathway_gene_list, "\\s*,\\s*", simplify = TRUE))
+        } else {
+          pathway_go <- getQueryString()$go
+          pathway_row <- pathways %>%
+            filter(go == pathway_go)
+          pathway_row$data[[1]]$gene
+        }
       }
     }
   })
@@ -457,15 +463,17 @@ gene_callback <- function(input, output, session) {
   output$text_neg_enrich <- renderText({paste0("Pathways of genes with inverse dependencies as ", str_c(data(), collapse = ", "))})
 
   output$detail_summary <- renderUI({
-    content <- getQueryString()$content
-    if (content == 'gene') {
-      gene_summary_ui(data())
-    } else {
-      pathway_gene_list <- getQueryString()$gene_list
-      if (!is.null(pathway_gene_list)) {
-        gene_list_summary_ui(str_split(pathway_gene_list, "\\s*,\\s*", simplify = TRUE))
+    if (detail_page_visible()) {
+      content <- getQueryString()$content
+      if (content == 'gene') {
+        gene_summary_ui(data())
       } else {
-        pathway_summary_ui(getQueryString()$go)   
+        pathway_gene_list <- getQueryString()$gene_list
+        if (!is.null(pathway_gene_list)) {
+          gene_list_summary_ui(str_split(pathway_gene_list, "\\s*,\\s*", simplify = TRUE))
+        } else {
+          pathway_summary_ui(getQueryString()$go)
+        }
       }
     }
     # render details about the gene symbol or pathway user chose


### PR DESCRIPTION
# Custom Gene List Searching

When a user's search contains comma separated strings the app assumes they are providing a custom gene list. I haven't updated any help text about this so it is currently a hidden feature.
When a user searches for a custom gene list only one row is returned and that is custom gene list.

## Search Results
Right now the custom gene list search result is really bare bones/ugly:
<img width="556" alt="Screen Shot 2020-05-02 at 10 00 25 AM" src="https://user-images.githubusercontent.com/1024463/80866277-c6983d80-8c5b-11ea-8cf4-908e8babf95e.png">
To generate the data for the above the `gene_list_query_results_table` function returns a dataframe with a `data` column that contains a list of gene_summary rows. These gene_summary rows have a new boolean `known` field to denote which rows are actually in gene_summary and which are not found. There may be a better way to organize this so feel free to make a suggestion.

This could be expanded to include more details about the known genes and make it more obvious what to click. We may also want to consider including gene and pathway search results for the individual items in case a user didn't mean to look for a custom gene list. They may have entered multiple genes and want to look at them one at a time.

We may also want to consider searching in the aka field in addition to approved_symbol field when checking for known genes.

## Summary
As of this change the top two lines of the custom gene list summary are kind of repetitive:
<img width="676" alt="Screen Shot 2020-05-02 at 10 04 22 AM" src="https://user-images.githubusercontent.com/1024463/80866387-5b9b3680-8c5c-11ea-9159-c2a883b8cde9.png">

# Other Fixes
Includes a fix to handle a problem where shiny tries to re-render the detail summary page when user searches.  See https://github.com/matthewhirschey/ddh/commit/545b15dcd115127941987adf0402c83d769912f

Removes `title` column from search results since it wasn't being used anywhere.
