### PR TITLE
update Dockerfile to tidyverse 3.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM rocker/tidyverse:3.6.1
+FROM rocker/tidyverse:3.6.3
 RUN install2.r --deps TRUE here janitor corrr beepr enrichR moderndive pander vroom rentrez feather optparse tidytext widyr doParallel


### PR DESCRIPTION
This is to fix an issue building pathways.Rds using create_pathways.R.
Previously with tidyverse version 3.6.1 the `def` field was missing data.