### PR TITLE
rocker tidyverse 3.6.1 and create_pathways.R def fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM rocker/tidyverse:3.6.3
+FROM rocker/tidyverse:3.6.1
 RUN install2.r --deps TRUE here janitor corrr beepr enrichR moderndive pander vroom rentrez feather optparse tidytext widyr doParallel
 RUN Rscript -e 'devtools::install_github("jespermaag/gganatogram")'

--- a/code/create_pathways.R
+++ b/code/create_pathways.R
@@ -50,6 +50,7 @@ go_def <- read_delim(go_def_url, delim = "\n", col_names = "X1") %>%
   select(X1, X2, id) %>% 
   filter(X1 != "id") %>% 
   pivot_wider(names_from = X1, values_from = X2) %>% 
+  mutate_at(vars(def), unlist) %>% # unlist def column for rocker/tidyverse:3.6.1 compatibility
   mutate(def = str_remove_all(def, '\\"'))
 
 #join


### PR DESCRIPTION
Reverts back to 3.6.1 to fix #93. Adds code to unlist def column in pathways data to
be compatible with the rocker tidyverse image.
Fix to create_pathways based on `3rd issue` at https://github.com/tidyverse/tidyr/issues/737

Fixes #93