### PR TITLE
make openshift file downloading code generic

### DIFF
--- a/openshift/download-ddh-data.py
+++ b/openshift/download-ddh-data.py
@@ -1,23 +1,10 @@
 import DukeDS
 import os
 
-quarter = os.getenv('DDH_QUARTER', '20Q1')
+quarter = os.getenv('DDH_QUARTER', '20Q2')
 
-ddh_files = [
-  'gene_summary.Rds',
-  '{}_achilles.Rds'.format(quarter),
-  '{}_expression_join.Rds'.format(quarter),
-  'sd_threshold.Rds',
-  'achilles_lower.Rds',
-  'achilles_upper.Rds',
-  'mean_virtual_achilles.Rds',
-  'sd_virtual_achilles.Rds',
-  'master_bottom_table.Rds',
-  'master_top_table.Rds',
-  'master_positive.Rds',
-  'master_negative.Rds',
-  ]
-
+ddh_files = DukeDS.list_files('ddh-data')
 for ddh_file in ddh_files:
-  print(ddh_file)
-  DukeDS.download_file('ddh-data', 'data/{}'.format(ddh_file))
+  if ddh_file.startswith("/data/{}".format(quarter)):
+    print(ddh_file)
+    DukeDS.download_file('ddh-data', ddh_file)


### PR DESCRIPTION
Downloads all files in the DDS repo that start with the name of the quarter we are staging in.
This will prevent the need to manually curate this list in the future.

Fixes #98