### PR TITLE
render reports from Rmd in temp directory

### DIFF
--- a/code/fun_reports.R
+++ b/code/fun_reports.R
@@ -74,7 +74,7 @@ render_complete_report <- function (file,
   dep_bottom <- make_bottom_table(bottomtable_data, gene_symbol)
   flat_bottom_complete <- make_enrichment_bottom(enrichmentbottom_data, gene_symbol)
   graph_report <- make_graph_report(toptable_data, bottomtable_data, gene_symbol)
-  rmarkdown::render(here::here("code", "report_app.Rmd"), output_file = file)
+  rmarkdown::render("report_app.Rmd", output_file = file)
 }
 #render_complete_report(file = "tmp.pdf", gene_symbol = "SDHA", type = "gene")
 #render_complete_report(file = "tmp.pdf", gene_symbol = c("GHRHR", "CDH3", "GHRH", "IGF1", "PHIP", "WNT1", "GH1"), type = "pathway")
@@ -89,7 +89,7 @@ render_dummy_report <- function (file,
                           type, 
                           summary1, 
                           summary2)
-  rmarkdown::render(here::here("code", "report_dummy_app.Rmd"), output_file = file)
+  rmarkdown::render("report_dummy_app.Rmd", output_file = file)
 }
 #render_dummy_report(file = "tmp.pdf", gene_symbol = "SDHA", type = "gene")
 


### PR DESCRIPTION
We were trying to render the reports from the `/code` directory.
In OpenShift the `/code` directory is read only so this failed.
The code involved is rather hard to follow with some confusing duplications.
I will open an issue to cleanup this code to make it easier to follow.
This fix is just to get the site working again.

Fixes #100