### PR TITLE
simplify report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ config.sh
 logs
 venv
 ddh-data
+report

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ logs
 venv
 ddh-data
 report
+

--- a/code/fun_reports.R
+++ b/code/fun_reports.R
@@ -155,6 +155,8 @@ render_report_to_file <- function(file,
 }
 
 render_rmarkdown_in_tempdir <- function(rmd_path, output_file, envir = parent.frame()) {
+  # The rmd_path variable must be an absolute path.
+
   # make sure the base report directory exists
   report_base_dir = here::here("report")
   if (!file.exists(report_base_dir)) {

--- a/code/fun_reports.R
+++ b/code/fun_reports.R
@@ -74,7 +74,7 @@ render_complete_report <- function (file,
   dep_bottom <- make_bottom_table(bottomtable_data, gene_symbol)
   flat_bottom_complete <- make_enrichment_bottom(enrichmentbottom_data, gene_symbol)
   graph_report <- make_graph_report(toptable_data, bottomtable_data, gene_symbol)
-  rmarkdown::render(here::here("code", "report_app.Rmd"), output_file = file)
+  render_rmarkdown_in_tempdir(here::here("code", "report_app.Rmd"), output_file = file)
 }
 #render_complete_report(file = "tmp.pdf", gene_symbol = "SDHA", type = "gene")
 #render_complete_report(file = "tmp.pdf", gene_symbol = c("GHRHR", "CDH3", "GHRH", "IGF1", "PHIP", "WNT1", "GH1"), type = "pathway")
@@ -89,7 +89,7 @@ render_dummy_report <- function (file,
                           type, 
                           summary1, 
                           summary2)
-  rmarkdown::render(here::here("code", "report_dummy_app.Rmd"), output_file = file)
+  render_rmarkdown_in_tempdir(here::here("code", "report_dummy_app.Rmd"), output_file = file)
 }
 #render_dummy_report(file = "tmp.pdf", gene_symbol = "SDHA", type = "gene")
 
@@ -169,4 +169,23 @@ render_report_to_file <- function(file,
                                summary2)
     file.rename(out, file)
   }
+}
+
+render_rmarkdown_in_tempdir <- function(rmd_path, output_file, envir = parent.frame()) {
+  # make sure the base report directory exists
+  report_base_dir = here::here("report")
+  if (!file.exists(report_base_dir)) {
+    dir.create(report_base_dir)
+  }
+  # determine the filename of the Rmd file we will use for rendering
+  rmd_filename <- basename(rmd_path)
+  # create a temporary directory and make it our working directory
+  temp_dir <- tempfile(pattern="tmpdir", tmpdir=report_base_dir)
+  dir.create(temp_dir)
+  owd <- setwd(temp_dir)
+  on.exit(setwd(owd))
+  on.exit(unlink(temp_dir, recursive = TRUE))
+  # copy the Rmd file into our temporary(current) directory
+  file.copy(rmd_path, rmd_filename, overwrite = TRUE)
+  rmarkdown::render(rmd_filename, output_file = output_file, envir = envir)
 }

--- a/code/fun_reports.R
+++ b/code/fun_reports.R
@@ -84,7 +84,8 @@ render_dummy_report <- function (file,
                                  gene_symbol, 
                                  type, 
                                  summary1 = gene_summary, 
-                                 summary2 = pathways) {
+                                 summary2 = pathways,
+                                 achilles = achilles) {
   summary <- make_summary(gene_symbol, 
                           type, 
                           summary1, 
@@ -109,15 +110,6 @@ render_report_to_file <- function(file,
                                   enrichmentbottom_data = master_negative, 
                                   achilles_data = achilles) {
   if (gene_symbol %in% colnames(achilles_data) && length(gene_symbol) == 1) {
-    src <- normalizePath('report_app.Rmd')
-    
-    # temporarily switch to the temp dir, in case you do not have write
-    # permission to the current working directory
-    
-    owd <- setwd(tempdir())
-    on.exit(setwd(owd))
-    
-    file.copy(src, 'report_app.Rmd', overwrite = TRUE)
     out <- render_complete_report(file, 
                                   gene_symbol, 
                                   type,
@@ -135,11 +127,6 @@ render_report_to_file <- function(file,
                                   achilles_data)
     file.rename(out, file)
   } else if (length(gene_symbol) > 1) {
-    src <- normalizePath('report_app.Rmd')
-    owd <- setwd(tempdir())
-    on.exit(setwd(owd))
-    
-    file.copy(src, 'report_app.Rmd', overwrite = TRUE)
     out <- render_complete_report(file, 
                                   gene_symbol, 
                                   type,
@@ -157,16 +144,12 @@ render_report_to_file <- function(file,
                                   achilles_data)
     file.rename(out, file)
   } else {
-    src <- normalizePath('report_dummy_app.Rmd')
-    owd <- setwd(tempdir())
-    on.exit(setwd(owd))
-    
-    file.copy(src, 'report_dummy_app.Rmd', overwrite = TRUE)
     out <- render_dummy_report(file, 
                                gene_symbol, 
                                type, 
                                summary1, 
-                               summary2)
+                               summary2,
+                               cellbins_data)
     file.rename(out, file)
   }
 }

--- a/openshift/Deployment.yaml
+++ b/openshift/Deployment.yaml
@@ -44,6 +44,8 @@ items:
             name: ddh-data
           - mountPath: /srv/user-data
             name: ddh-user-data
+          - mountPath: /srv/reports
+            name: ddh-reports
         volumes:
         - name: ddh-data
           readOnly: true
@@ -52,6 +54,8 @@ items:
         - name: ddh-user-data
           persistentVolumeClaim:
             claimName: ddh-user-data-pvc
+        - name: ddh-reports
+          emptyDir: {}
     triggers:
     - imageChangeParams:
         automatic: true


### PR DESCRIPTION
Moves logic to create and run in a temp directory to one location.
Removes duplicate Rmd filenames.

Adds a new `report` directory used for PDF generation. 
Inside this directory new temporary directories will be created when rendering reports. 

Adds `achilles` to fix rendering `report_dummy_app.Rmd` (example gene `WASH7P`).

Updates OpenShift deployment template to create a temporary `reports` directory.

Fixes #104 