### PR TITLE
Adds script to pull changes from ddh.com repo

### DIFF
--- a/pullchanges.sh
+++ b/pullchanges.sh
@@ -13,7 +13,7 @@ set -e
 DESTBRANCH=ddh-com-$(date +"%Y-%m-%d_%H%M")
 
 # upstream branch to pull changes from
-UPBRANCH=org-reorg
+UPBRANCH=master
 
 unstagefiles () {
   PATTERN=$1

--- a/pullchanges.sh
+++ b/pullchanges.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Creates a new branch and pulls changes from ddh.com
+
+# branch to hold changes
+DESTBRANCH=ddh-com-$(date +"%Y-%m-%d_%H%M")
+
+# upstream branch to pull changes from
+UPBRANCH=org-reorg
+
+echo "Switching to master branch and pulling"
+# make sure we are on the ddh.org master branch and up to date
+git checkout master
+git pull
+
+# add a remote named upstream pointing to ddh.com
+git ls-remote --exit-code upstream 2>/dev/null >/dev/null
+RETVAL=$?
+if [ $RETVAL -eq 0 ]
+then
+   echo "Upstream remote already exists."
+else
+   echo "Adding upstream remote to ddh.com"
+   git remote add upstream git@github.com:matthewhirschey/ddh.com.git
+fi
+
+echo "Fetching $UPBRANCH remote changes"
+git fetch upstream $UPBRANCH
+
+echo "Creating and switching to new $DESTBRANCH branch"
+git checkout -b $DESTBRANCH
+
+echo "Merging all changes from upstream/$UPBRANCH"
+git merge --squash --no-commit -X theirs upstream/$UPBRANCH
+
+echo "Removing private files from staged changes"
+PRIVATE_FILES=$(git diff --staged --name-only | grep '_private.R$')
+for PRIVATE_FILE in $PRIVATE_FILES
+do
+   git rm -f $PRIVATE_FILE
+done
+
+echo "Committing changes to $DESTBRANCH"
+MSGFILE=$(mktemp)
+MSGDATE=$(date +"%Y-%m-%d")
+echo "pulled changes from matthewhirschey/ddh.com on $MSGDATE" > $MSGFILE
+echo "" >> $MSGFILE
+echo "This commit was created using pullchanges.sh" >> $MSGFILE
+echo "" >> $MSGFILE
+echo "latest commit from ddh.com $UPBRANCH" >> $MSGFILE
+git log -1 --stat upstream/$UPBRANCH >> $MSGFILE
+echo "" >> $MSGFILE
+git commit --file=$MSGFILE
+rm $MSGFILE
+
+echo "Done"
+

--- a/pullchanges.sh
+++ b/pullchanges.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
-# Creates a new branch and pulls changes from ddh.com
+# Creates a new branch, pulls changes from ddh.com, pushes the branch
+# and creates a github pull request.
+# This script requires the gh command can be installed.
+# See https://cli.github.com/ to install gh.
+# You should run `gh auth login` once to authenticate with github before
+# running this script.
+
+# turn on command exit status checking
+set -e
 
 # branch to hold changes
 DESTBRANCH=ddh-com-$(date +"%Y-%m-%d_%H%M")
@@ -27,6 +35,9 @@ echo "Switching to master branch and pulling"
 git checkout master
 git pull
 
+# turn off command exit status checking for git ls-remote
+set +e
+
 # add a remote named upstream pointing to ddh.com
 git ls-remote --exit-code upstream 2>/dev/null >/dev/null
 RETVAL=$?
@@ -38,8 +49,8 @@ else
    git remote add upstream git@github.com:matthewhirschey/ddh.com.git
 fi
 
-# turn on error checking
-set -e 
+# turn on command exit status checking
+set -e
 
 echo "Fetching $UPBRANCH remote changes"
 git fetch upstream $UPBRANCH
@@ -74,6 +85,12 @@ git log -1 --stat upstream/$UPBRANCH >> $MSGFILE
 echo "" >> $MSGFILE
 git commit --file=$MSGFILE
 rm $MSGFILE
+
+echo "Pushing branch to origin(github)"
+git push -u origin $DESTBRANCH
+
+echo "Creating a pull request on github"
+gh pr create --base master -w
 
 echo "Done"
 


### PR DESCRIPTION
Adds top level `pullchanges.sh` script.
This script switches to the master branch, creates a new git branch based on master, pulls changes from ddh.com skipping specific files, then commits the remaining files to the new branch. The new branch is then pushed and your web browser is opened to create a github pull request.

The script requires the github command line too(gh)l to be installed. 
Instructions to install it are at https://cli.github.com/.

The files skipped from ddh.com repo are as follows:
Any file ending in `_private.R`.
Any file within the `openshift`or `tests/data` directories.
Any file named `README.md`.

NOTE: Currently the upstream branch in `pullchanges.sh` is hard coded to the `org-reorg` ddh.com branch. This will need to be changed to `master` once the `org-reorg` branch is merged. It would be a good idea to make these changes before merging this PR.