### PR TITLE
Add rtweet library for twitterbot

### DIFF
--- a/base-shiny/Dockerfile
+++ b/base-shiny/Dockerfile
@@ -36,6 +36,9 @@ RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE \
  htmltools \
  gt
 
+# install rtweet for twitter bot
+RUN install2.r --repos http://archive.linux.duke.edu/cran/ --deps TRUE rtweet
+
 RUN Rscript -e 'devtools::install_github("jespermaag/gganatogram")'
 
 # Install and register "Roboto Slab" and "Nunito Sans" fonts


### PR DESCRIPTION
Adds back in the rtweet library for the twitterbot cron job.
This library was accidentally removed by https://github.com/matthewhirschey/ddh/commit/431253baafc665c3bddb724a7c14b4ac2f5567fc#diff-fb8c8012a506319f035d3c7564249935bbe3b4b48a0e9b8e2af7527f09674dd7.
The installation of rtweet is moved to a separate line to avoid future problems with pullchanges.sh.